### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+orchestra

--- a/commands/build.go
+++ b/commands/build.go
@@ -20,7 +20,7 @@ var BuildCommand = &cli.Command{
 	BashComplete: ServicesBashComplete,
 }
 
-func BuildAction(c *cli.Context) {
+func BuildAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			buildService(c, service)
@@ -33,6 +33,7 @@ func BuildAction(c *cli.Context) {
 		pool.Do(worker(service))
 	}
 	pool.Drain()
+	return nil
 }
 
 func buildService(c *cli.Context, service *services.Service) {

--- a/commands/build.go
+++ b/commands/build.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/codegangsta/cli"
+	"github.com/wsxiaoys/terminal"
+
+	"github.com/mondough/orchestra/services"
+)
+
+var BuildCommand = &cli.Command{
+	Name:         "build",
+	Usage:        "Build service(s)",
+	Action:       BeforeAfterWrapper(BuildAction),
+	BashComplete: ServicesBashComplete,
+}
+
+func BuildAction(c *cli.Context) {
+	wg := &sync.WaitGroup{}
+	for _, service := range FilterServices(c) {
+		wg.Add(1)
+		go buildService(wg, c, service)
+	}
+	wg.Wait()
+}
+
+func buildService(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
+	defer wg.Done()
+	spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
+
+	cmd := exec.Command("go", "build", "-v")
+	cmd.Dir = service.Path
+	output := new(bytes.Buffer)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if cmd.Run() != nil {
+		outputStr := output.String()
+		appendError(fmt.Errorf("Failed to build service %s\n%s", service.Name, outputStr))
+		terminal.Stdout.Colorf("%s%s| @{r} error: @{|}Failed to build: %s\n", service.Name, spacing, outputStr)
+	} else {
+		terminal.Stdout.Colorf("%s%s| @{g} (re)built\n", service.Name, spacing)
+	}
+}

--- a/commands/build.go
+++ b/commands/build.go
@@ -28,7 +28,8 @@ func BuildAction(c *cli.Context) {
 	}
 
 	pool := make(workerPool, runtime.NumCPU())
-	for _, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		pool.Do(worker(service))
 	}
 	pool.Drain()

--- a/commands/export.go
+++ b/commands/export.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 
-	"github.com/b2aio/orchestra/config"
+	"github.com/mondough/orchestra/config"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/export.go
+++ b/commands/export.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/mondough/orchestra/config"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/config"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/export.go
+++ b/commands/export.go
@@ -15,8 +15,9 @@ var ExportCommand = &cli.Command{
 	BashComplete: ServicesBashComplete,
 }
 
-func ExportAction(c *cli.Context) {
+func ExportAction(c *cli.Context) error {
 	for key, value := range config.GetBaseEnvVars() {
 		terminal.Stdout.Print(fmt.Sprintf("export %s=%s\n", key, value))
 	}
+	return nil
 }

--- a/commands/install.go
+++ b/commands/install.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
+	"github.com/wsxiaoys/terminal"
+)
+
+var InstallCommand = &cli.Command{
+	Name:         "install",
+	Usage:        "Installs all the services",
+	Action:       BeforeAfterWrapper(InstallAction),
+	BashComplete: ServicesBashComplete}
+
+// InstallAction installs all the services (or the specified ones)
+func InstallAction(c *cli.Context) {
+	worker := func(service *services.Service) func() {
+		return func() {
+			spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
+			rebuilt, err := installService(service)
+			if err != nil {
+				appendError(err)
+				terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%v\n", service.Name, spacing, err)
+			} else if rebuilt {
+				terminal.Stdout.Colorf("%s%s| @{g} installed\n", service.Name, spacing)
+			} else {
+				terminal.Stdout.Colorf("%s%s| @{g} already up to date\n", service.Name, spacing)
+			}
+		}
+	}
+
+	pool := make(workerPool, runtime.NumCPU())
+	for _, service := range FilterServices(c) {
+		pool.Do(worker(service))
+	}
+	pool.Drain()
+}
+
+// installService runs go install in the service directory
+func installService(service *services.Service) (bool, error) {
+	cmd := exec.Command("nice", "-n", niceness, "go", "install", "-v")
+	cmd.Dir = service.Path
+	output := bytes.NewBuffer([]byte{})
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Start()
+	if err != nil {
+		return false, err
+	}
+	cmd.Wait()
+	if !cmd.ProcessState.Success() {
+		return false, fmt.Errorf("Failed to install service %s\n%s", service.Name, output.String())
+	} else if output.Len() > 0 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/commands/install.go
+++ b/commands/install.go
@@ -19,7 +19,7 @@ var InstallCommand = &cli.Command{
 	BashComplete: ServicesBashComplete}
 
 // InstallAction installs all the services (or the specified ones)
-func InstallAction(c *cli.Context) {
+func InstallAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -40,6 +40,7 @@ func InstallAction(c *cli.Context) {
 		pool.Do(worker(service))
 	}
 	pool.Drain()
+	return nil
 }
 
 // installService runs go install in the service directory

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 
 	"github.com/ActiveState/tail"
-	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -43,6 +43,7 @@ func ConsumeLogs() {
 }
 
 func TailServiceLog(service *services.Service, wg *sync.WaitGroup) {
+	defer wg.Done()
 	spacingLength := services.MaxServiceNameLength + 2 - len(service.Name)
 	t, err := tail.TailFile(service.LogFilePath, tail.Config{Follow: true})
 	if err != nil {
@@ -51,5 +52,4 @@ func TailServiceLog(service *services.Service, wg *sync.WaitGroup) {
 	for line := range t.Lines {
 		logReceiver <- fmt.Sprintf("@{%s}%s@{|}%s|  %s\n", service.Color, service.Name, strings.Repeat(" ", spacingLength), line.Text)
 	}
-	wg.Done()
 }

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -25,7 +25,7 @@ func init() {
 	logReceiver = make(chan string)
 }
 
-func LogsAction(c *cli.Context) {
+func LogsAction(c *cli.Context) error {
 	go ConsumeLogs()
 	wg := &sync.WaitGroup{}
 	for _, service := range FilterServices(c) {
@@ -34,6 +34,7 @@ func LogsAction(c *cli.Context) {
 	}
 	wg.Wait()
 	close(logReceiver)
+	return nil
 }
 
 func ConsumeLogs() {

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/ActiveState/tail"
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ActiveState/tail"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
+	"github.com/hpcloud/tail"
 	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -21,12 +21,13 @@ var PsCommand = &cli.Command{
 
 // PsAction checks the status for every service and output
 func PsAction(c *cli.Context) {
-	for name, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 		if service.Process != nil {
-			terminal.Stdout.Colorf("@{g}%s", name).Reset().Colorf("%s|", spacing).Print(" running ").Colorf("  %d  %s\n", service.Process.Pid, getPorts(service))
+			terminal.Stdout.Colorf("@{g}%s", service.Name).Reset().Colorf("%s|", spacing).Print(" running ").Colorf("  %d  %s\n", service.Process.Pid, getPorts(service))
 		} else {
-			terminal.Stdout.Colorf("@{r}%s", name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
+			terminal.Stdout.Colorf("@{r}%s", service.Name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
 		}
 	}
 }

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -33,7 +33,7 @@ func PsAction(c *cli.Context) {
 
 func getPorts(service *services.Service) string {
 	re := regexp.MustCompile("LISTEN")
-	cmd := exec.Command("lsof", "-p", fmt.Sprintf("%d", service.Process.Pid))
+	cmd := exec.Command("lsof", "-P", "-p", fmt.Sprintf("%d", service.Process.Pid))
 	output := bytes.NewBuffer([]byte{})
 	cmd.Stdout = output
 	cmd.Stderr = output

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -27,8 +27,8 @@ func PsAction(c *cli.Context) {
 	var wg sync.WaitGroup
 	for _, svc := range svcs {
 		wg.Add(1)
-		go func(svc *services.Service) {
-			svc.Ports = getPorts(svc)
+		go func(s *services.Service) {
+			s.Ports = getPorts(s)
 			wg.Done()
 		}(svc)
 	}
@@ -45,6 +45,10 @@ func PsAction(c *cli.Context) {
 }
 
 func getPorts(service *services.Service) string {
+	if service.Process == nil {
+		return ""
+	}
+
 	re := regexp.MustCompile("LISTEN")
 	cmd := exec.Command("lsof", "-P", "-p", fmt.Sprintf("%d", service.Process.Pid))
 	output := bytes.NewBuffer([]byte{})

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -21,7 +21,7 @@ var PsCommand = &cli.Command{
 }
 
 // PsAction checks the status for every service and output
-func PsAction(c *cli.Context) {
+func PsAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 
 	var wg sync.WaitGroup
@@ -42,6 +42,7 @@ func PsAction(c *cli.Context) {
 			terminal.Stdout.Colorf("@{r}%s", service.Name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
 		}
 	}
+	return nil
 }
 
 func getPorts(service *services.Service) string {

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -40,6 +40,7 @@ func RestartAction(c *cli.Context) {
 }
 
 func restart(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
+	defer wg.Done()
 	spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 
 	err := killService(service)
@@ -62,6 +63,4 @@ func restart(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 	}
 
 	terminal.Stdout.Colorf("%s%s| @{c} %srestarted\n", service.Name, spacing, rebuiltStatus)
-
-	wg.Done()
 }

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -35,7 +35,8 @@ func RestartAction(c *cli.Context) {
 	}
 
 	pool := make(workerPool, runtime.NumCPU())
-	for _, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		pool.Do(worker(service))
 	}
 	pool.Drain()

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -27,7 +27,7 @@ var RestartCommand = &cli.Command{
 }
 
 // RestartAction restarts all the services (or the specified ones)
-func RestartAction(c *cli.Context) {
+func RestartAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			restart(c, service)
@@ -44,6 +44,7 @@ func RestartAction(c *cli.Context) {
 	if c.Bool("attach") || c.Bool("logs") {
 		LogsAction(c)
 	}
+	return nil
 }
 
 func restart(c *cli.Context, service *services.Service) {

--- a/commands/start.go
+++ b/commands/start.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -55,7 +54,7 @@ func start(c *cli.Context, service *services.Service) {
 		rebuilt, err := buildAndStart(c, service)
 		if err != nil {
 			appendError(err)
-			terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%s\n", service.Name, spacing, err.Error())
+			terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%v\n", service.Name, spacing, err)
 		} else {
 			var rebuiltStatus string
 			if rebuilt {
@@ -107,24 +106,4 @@ func buildAndStart(c *cli.Context, service *services.Service) (bool, error) {
 		return rebuilt, fmt.Errorf("Service %s exited after %s", cmd.ProcessState.UserTime().String())
 	}
 	return rebuilt, nil
-}
-
-// installService runs go install in the service directory
-func installService(service *services.Service) (bool, error) {
-	cmd := exec.Command("nice", "-n", niceness, "go", "install", "-v")
-	cmd.Dir = service.Path
-	output := bytes.NewBuffer([]byte{})
-	cmd.Stdout = output
-	cmd.Stderr = output
-	err := cmd.Start()
-	if err != nil {
-		return false, err
-	}
-	cmd.Wait()
-	if !cmd.ProcessState.Success() {
-		return false, fmt.Errorf("Failed to install service %s\n%s", service.Name, output.String())
-	} else if output.Len() > 0 {
-		return true, nil
-	}
-	return false, nil
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -40,7 +40,8 @@ func StartAction(c *cli.Context) {
 	}
 
 	pool := make(workerPool, runtime.NumCPU())
-	for _, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		pool.Do(worker(service))
 	}
 	pool.Drain()

--- a/commands/start.go
+++ b/commands/start.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -47,6 +47,7 @@ func StartAction(c *cli.Context) {
 }
 
 func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
+	defer wg.Done()
 	spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 	if service.Process == nil {
 		rebuilt, err := buildAndStart(c, service)
@@ -63,7 +64,6 @@ func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 	} else {
 		terminal.Stdout.Colorf("%s%s| @{c} already running\n", service.Name, spacing)
 	}
-	wg.Done()
 }
 
 // startService takes a Service struct as input, creates a new log file in .orchestra,

--- a/commands/start.go
+++ b/commands/start.go
@@ -57,7 +57,7 @@ func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 		} else {
 			var rebuiltStatus string
 			if rebuilt {
-				rebuiltStatus = "rebuilt & "
+				rebuiltStatus = "(re)built and "
 			}
 			terminal.Stdout.Colorf("%s%s| @{g} %sstarted\n", service.Name, spacing, rebuiltStatus)
 		}
@@ -73,7 +73,7 @@ func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 func buildAndStart(c *cli.Context, service *services.Service) (bool, error) {
 	cmd := exec.Command(service.BinPath)
 
-	rebuilt, err := buildService(service)
+	rebuilt, err := installService(service)
 	if err != nil {
 		return rebuilt, err
 	}
@@ -107,8 +107,8 @@ func buildAndStart(c *cli.Context, service *services.Service) (bool, error) {
 	return rebuilt, nil
 }
 
-// buildService runs go install in the service directory
-func buildService(service *services.Service) (bool, error) {
+// installService runs go install in the service directory
+func installService(service *services.Service) (bool, error) {
 	cmd := exec.Command("go", "install", "-v")
 	cmd.Dir = service.Path
 	output := bytes.NewBuffer([]byte{})

--- a/commands/start.go
+++ b/commands/start.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/start.go
+++ b/commands/start.go
@@ -33,7 +33,7 @@ var StartCommand = &cli.Command{
 }
 
 // StartAction starts all the services (or the specified ones)
-func StartAction(c *cli.Context) {
+func StartAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() { start(c, service) }
 	}
@@ -47,6 +47,7 @@ func StartAction(c *cli.Context) {
 	if c.Bool("attach") || c.Bool("logs") {
 		LogsAction(c)
 	}
+	return nil
 }
 
 func start(c *cli.Context, service *services.Service) {

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -17,7 +17,7 @@ var StopCommand = &cli.Command{
 }
 
 // StopAction stops all the services (or the specified ones)
-func StopAction(c *cli.Context) {
+func StopAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -29,6 +29,7 @@ func StopAction(c *cli.Context) {
 			terminal.Stdout.Colorf("%s%s| @{r} stopped\n", service.Name, spacing)
 		}
 	}
+	return nil
 }
 
 func killService(service *services.Service) error {

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -18,7 +18,8 @@ var StopCommand = &cli.Command{
 
 // StopAction stops all the services (or the specified ones)
 func StopAction(c *cli.Context) {
-	for _, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 		err := killService(service)
 		if err != nil {

--- a/commands/test.go
+++ b/commands/test.go
@@ -28,7 +28,8 @@ var TestCommand = &cli.Command{
 
 // StartAction starts all the services (or the specified ones)
 func TestAction(c *cli.Context) {
-	for _, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 		success, err := testService(c, service)
 		if err != nil {

--- a/commands/test.go
+++ b/commands/test.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
 	"github.com/wsxiaoys/terminal"
 )

--- a/commands/test.go
+++ b/commands/test.go
@@ -27,7 +27,7 @@ var TestCommand = &cli.Command{
 }
 
 // StartAction starts all the services (or the specified ones)
-func TestAction(c *cli.Context) {
+func TestAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -42,6 +42,7 @@ func TestAction(c *cli.Context) {
 			terminal.Stdout.Colorf("%s%s| @{g} PASS\n", service.Name, spacing)
 		}
 	}
+	return nil
 }
 
 // startService takes a Service struct as input, creates a new log file in .orchestra,

--- a/commands/test.go
+++ b/commands/test.go
@@ -56,7 +56,8 @@ func testService(c *cli.Context, service *services.Service) (bool, error) {
 		cmdArgs = append(cmdArgs, "--race")
 	}
 	cmdArgs = append(cmdArgs, "./...")
-	cmd := exec.Command("go", cmdArgs...)
+	cmdArgs = append([]string{"-n", niceness, "go"}, cmdArgs...)
+	cmd := exec.Command("nice", cmdArgs...)
 	cmd.Dir = service.Path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/commands/test.go
+++ b/commands/test.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -65,8 +65,8 @@ func ServicesBashComplete(c *cli.Context) {
 	}
 }
 
-func BeforeAfterWrapper(f func(c *cli.Context)) func(c *cli.Context) {
-	return func(c *cli.Context) {
+func BeforeAfterWrapper(f func(c *cli.Context) error) func(c *cli.Context) error {
+	return func(c *cli.Context) error {
 		err := config.GetBeforeFunc()(c)
 		if err != nil {
 			appendError(err)
@@ -76,6 +76,7 @@ func BeforeAfterWrapper(f func(c *cli.Context)) func(c *cli.Context) {
 		if err != nil {
 			appendError(err)
 		}
+		return nil
 	}
 }
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mondough/orchestra/config"
-	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/config"
+	"github.com/mondough/orchestra/services"
 )
 
 // This is temporary, very very alpha and may change soon

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -12,6 +12,10 @@ import (
 	"github.com/mondough/orchestra/services"
 )
 
+// niceness used for subprocesses
+// https://en.wikipedia.org/wiki/Nice_(Unix)
+const niceness = "1"
+
 // This is temporary, very very alpha and may change soon
 func FilterServices(c *cli.Context) map[string]*services.Service {
 	excludeMode := 0
@@ -79,4 +83,20 @@ func BeforeAfterWrapper(f func(c *cli.Context)) func(c *cli.Context) {
 // including the ones specified in the global config
 func GetEnvForService(c *cli.Context, service *services.Service) []string {
 	return append(service.Env, config.GetEnvForCommand(c)...)
+}
+
+type workerPool chan struct{}
+
+func (p workerPool) Drain() {
+	for i := 0; i < cap(p); i++ {
+		p <- struct{}{}
+	}
+}
+
+func (p workerPool) Do(impl func()) {
+	p <- struct{}{}
+	go func() {
+		defer func() { <-p }()
+		impl()
+	}()
 }

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/b2aio/orchestra/config"
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/config"
+	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Logs    ContextConfig `logs,omitempty`
 	Test    ContextConfig `test,omitempty`
 	Export  ContextConfig `export,omitempty`
+	Build   ContextConfig `build,omitempty`
 }
 
 func GetBaseEnvVars() map[string]string {

--- a/config/config.go
+++ b/config/config.go
@@ -31,14 +31,15 @@ type Config struct {
 	GoRun  bool              `gorun,omitempty`
 
 	// Configuration for Commands
+	Build   ContextConfig `build,omitempty`
+	Export  ContextConfig `export,omitempty`
+	Install ContextConfig `install,omitempty`
+	Logs    ContextConfig `logs,omitempty`
+	Ps      ContextConfig `ps,omitempty`
+	Restart ContextConfig `restart,omitempty`
 	Start   ContextConfig `start,omitempty`
 	Stop    ContextConfig `stop,omitempty`
-	Restart ContextConfig `restart,omitempty`
-	Ps      ContextConfig `ps,omitempty`
-	Logs    ContextConfig `logs,omitempty`
 	Test    ContextConfig `test,omitempty`
-	Export  ContextConfig `export,omitempty`
-	Build   ContextConfig `build,omitempty`
 }
 
 func GetBaseEnvVars() map[string]string {

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/b2aio/orchestra/commands"
-	"github.com/b2aio/orchestra/config"
-	"github.com/b2aio/orchestra/services"
+	"github.com/mondough/orchestra/commands"
+	"github.com/mondough/orchestra/config"
+	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
 )

--- a/main.go
+++ b/main.go
@@ -22,18 +22,17 @@ func main() {
 	app = cli.NewApp()
 	app.Name = "Orchestra"
 	app.Usage = "Orchestrate Go Services"
-	app.Author = "Vincenzo Prignano"
-	app.Email = ""
 	app.EnableBashCompletion = true
 	app.Commands = []cli.Command{
+		*commands.BuildCommand,
 		*commands.ExportCommand,
+		*commands.InstallCommand,
+		*commands.LogsCommand,
+		*commands.PsCommand,
+		*commands.RestartCommand,
 		*commands.StartCommand,
 		*commands.StopCommand,
-		*commands.LogsCommand,
-		*commands.RestartCommand,
-		*commands.PsCommand,
 		*commands.TestCommand,
-		*commands.BuildCommand,
 	}
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -6,11 +6,11 @@ import (
 	"path"
 	"path/filepath"
 
+	log "github.com/cihub/seelog"
+	"github.com/codegangsta/cli"
 	"github.com/mondough/orchestra/commands"
 	"github.com/mondough/orchestra/config"
 	"github.com/mondough/orchestra/services"
-	log "github.com/cihub/seelog"
-	"github.com/codegangsta/cli"
 )
 
 var app *cli.App

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		*commands.RestartCommand,
 		*commands.PsCommand,
 		*commands.TestCommand,
+		*commands.BuildCommand,
 	}
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 
 var app *cli.App
 
+const defaultConfigFile = "orchestra.yml"
+
 func main() {
 	defer log.Flush()
 	app = cli.NewApp()
@@ -43,7 +45,12 @@ func main() {
 	// init checks for an existing orchestra.yml in the current working directory
 	// and creates a new .orchestra directory (if doesn't exist)
 	app.Before = func(c *cli.Context) error {
-		config.ConfigPath, _ = filepath.Abs(c.GlobalString("config"))
+		confVal := c.GlobalString("config")
+		if confVal == "" {
+			confVal = defaultConfigFile
+		}
+
+		config.ConfigPath, _ = filepath.Abs(confVal)
 		if _, err := os.Stat(config.ConfigPath); os.IsNotExist(err) {
 			fmt.Printf("No %s found. Have you specified the right directory?\n", c.GlobalString("config"))
 			os.Exit(1)

--- a/services/services.go
+++ b/services/services.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -36,6 +37,29 @@ func init() {
 // and starts the service discovery
 func Init() {
 	DiscoverServices()
+}
+
+func Sort(r map[string]*Service) SortableRegistry {
+	sr := make(SortableRegistry, 0)
+	for _, v := range r {
+		sr = append(sr, v)
+	}
+	sort.Sort(sr)
+	return sr
+}
+
+type SortableRegistry []*Service
+
+func (s SortableRegistry) Len() int {
+	return len(s)
+}
+
+func (s SortableRegistry) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s SortableRegistry) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
 }
 
 // Service encapsulates all the information needed for a service

--- a/services/services.go
+++ b/services/services.go
@@ -107,8 +107,7 @@ func DiscoverServices() {
 					LogFilePath:   fmt.Sprintf("%s/%s.log", OrchestraServicePath, serviceName),
 					PidFilePath:   fmt.Sprintf("%s/%s.pid", OrchestraServicePath, serviceName),
 					Color:         colors[len(Registry)%len(colors)],
-					Path:          fmt.Sprintf("%s/%s", ProjectPath, serviceName),
-				}
+					Path:          fmt.Sprintf("%s/%s", ProjectPath, serviceName)}
 
 				// Parse env variable in configuration
 				var serviceConfig struct {

--- a/services/services.go
+++ b/services/services.go
@@ -82,7 +82,8 @@ func (s *Service) IsRunning() bool {
 // for the service.yml file. For every service it registers it after trying
 // to import the package using Go's build.Import package
 func DiscoverServices() {
-	buildPath := strings.Replace(ProjectPath, os.Getenv("GOPATH")+"/src/", "", 1)
+	gopath := strings.TrimRight(os.Getenv("GOPATH"), "/")
+	buildPath := strings.Replace(ProjectPath, gopath+"/src/", "", 1)
 	fd, _ := ioutil.ReadDir(ProjectPath)
 	for _, item := range fd {
 		serviceName := item.Name()

--- a/services/services.go
+++ b/services/services.go
@@ -80,6 +80,7 @@ type Service struct {
 	PackageInfo *build.Package
 	Process     *os.Process
 	Env         []string
+	Ports       string
 }
 
 func (s *Service) IsRunning() bool {


### PR DESCRIPTION
Fix deprecation warnings from upstream CLI library.

`DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature`
